### PR TITLE
Do not use preventDefault in touch-event-listeners

### DIFF
--- a/src/slideshow.js
+++ b/src/slideshow.js
@@ -414,18 +414,15 @@ function Slideshow(slideshow_options) {
 		var slides = slide.div;
 
 		slides.bind(TouchMouseEvent.DOWN, function(e) {
-			e.preventDefault();
 			startX = e.pageX;
 			endX = startX;
 		});
 
 		slides.bind(TouchMouseEvent.MOVE, function(e) {
-			e.preventDefault();
 			endX = e.pageX;
 		});
 
 		slides.bind(TouchMouseEvent.UP, function(e) {
-			e.preventDefault();
 			var slideIndex = slides.index($(this));
 
 			//disable autoplay when user clicks next/prev buttons


### PR DESCRIPTION
Chrome does not convert taps to clicks anymore if preventDefault is used: https://developers.google.com/web/updates/2017/01/scrolling-intervention